### PR TITLE
disable prefer-rest-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@
     ```
 
   <a name="es6-rest"></a>
-  - [7.6](#7.6) <a name='7.6'></a> Never use `arguments`, opt to use rest syntax `...` instead. [`prefer-rest-params`](http://eslint.org/docs/rules/prefer-rest-params)
+  - [7.6](#7.6) <a name='7.6'></a> ~~Never use `arguments`, opt to use rest syntax `...` instead.~~ (*Note:* This is not supported by Node 4 out of the box. We have temporarily disabled the rule.) [`prefer-rest-params`](http://eslint.org/docs/rules/prefer-rest-params)
 
     > Why? `...` is explicit about which arguments you want pulled. Plus rest arguments are a real Array and not Array-like like `arguments`.
 

--- a/packages/eslint-config-agco/rules/es6.js
+++ b/packages/eslint-config-agco/rules/es6.js
@@ -57,9 +57,9 @@ module.exports = {
     'prefer-spread': 0,
     // suggest using Reflect methods where applicable
     'prefer-reflect': 0,
-    // use rest parameters instead of arguments
+    // use rest parameters instead of arguments. Disabled since it's not supported by Node 4
     // http://eslint.org/docs/rules/prefer-rest-params
-    'prefer-rest-params': 2,
+    'prefer-rest-params': 0,
     // suggest using template literals instead of string concatenation
     // http://eslint.org/docs/rules/prefer-template
     'prefer-template': 2,


### PR DESCRIPTION
Rest params are not supported by Node.js 4
