### PR TITLE
Fixed issue when requiring/resolving rules modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 *Our approach to JavaScript based off of [AirBnB's style guide](https://github.com/airbnb/javascript).*
 
 Other Style Guides
+ - [CSS & Sass](linters/css)
  - [React](linters/react/)
+
 
 ## Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agco-codestyle",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "AGCO's JavaScript code style guide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-agco/CHANGELOG.md
+++ b/packages/eslint-config-agco/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.0.5 / 2016-04-18
+==================
+- Fixed issue when resolving lint module names
+
 0.0.4 / 2016-04-18
 ==================
 - Added lint support for React/JSX applications

--- a/packages/eslint-config-agco/index.js
+++ b/packages/eslint-config-agco/index.js
@@ -4,6 +4,6 @@ module.exports = {
   extends: [
     'agco/configurations/es6',
     'agco/configurations/react'
-  ].map(require.resolve),
+  ],
   rules: {}
 };

--- a/packages/eslint-config-agco/package.json
+++ b/packages/eslint-config-agco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-agco",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "AGCO's ESLint config, following our style guide",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When adding react support a "require.resolve" was inserted by mistake, breaking the eslint-config-agco lint load.

It was removed to fix the issue once the paths do not match with the real folder tree structure (and require.resolve will fail).
