### PR TITLE
Allow param properties manipulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agco-codestyle",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "AGCO's JavaScript code style guide",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config-agco/CHANGELOG.md
+++ b/packages/eslint-config-agco/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.7 / 2017-09-07
+==================
+- Relaxed no-param-reassign
+- Upgraded packages
+
 0.0.5 / 2016-04-18
 ==================
 - Fixed issue when resolving lint module names

--- a/packages/eslint-config-agco/package.json
+++ b/packages/eslint-config-agco/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-agco",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "description": "AGCO's ESLint config, following our style guide",
   "main": "index.js",
   "scripts": {
@@ -30,16 +30,10 @@
   },
   "homepage": "https://github.com/agco/agco-codestyle#readme",
   "devDependencies": {
-    "eslint": "^2.2.0",
-    "eslint-plugin-import": "^1.4.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
-    "eslint-plugin-react": "^4.3.0",
+    "eslint": "^4.6.1",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.3.0",
     "react": "^15.0.1"
-  },
-  "peerDependencies": {
-    "eslint": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2",
-    "eslint-plugin-import": "^1.4.0",
-    "eslint-plugin-react": "^4.3.0"
   }
 }

--- a/packages/eslint-config-agco/rules/best-practices.js
+++ b/packages/eslint-config-agco/rules/best-practices.js
@@ -86,9 +86,9 @@ module.exports = {
     // var foo = 'Copyright \251';
     'no-octal-escape': 2,
     // disallow reassignment of function parameters
-    // disallow parameter object manipulation
+    // allow parameter object manipulation
     // rule: http://eslint.org/docs/rules/no-param-reassign.html
-    'no-param-reassign': [2, { 'props': true }],
+    'no-param-reassign': [2, { 'props': false }],
     // disallow use of process.env
     'no-process-env': 0,
     // disallow usage of __proto__ property

--- a/packages/eslint-config-agco/rules/style.js
+++ b/packages/eslint-config-agco/rules/style.js
@@ -136,7 +136,7 @@ module.exports = {
     // require or disallow a space immediately following the // or /* in a comment
     'spaced-comment': [2, 'always', {
       'exceptions': ['-', '+'],
-      'markers': ['=', '!']           // space here to support sprockets directives
+      'markers': ['=', '!']
     }],
     // require regex literals to be wrapped in parentheses
     'wrap-regex': 0


### PR DESCRIPTION
In lodash it's common to manipulate properties of param:
```
return _.reduce(array, (acc, item) => {
    if (item) {
      acc[item[propertyName]] = item;
    }
    return acc;
  }, {});
```